### PR TITLE
도커 파일 수정 & 빌드 스크립트 생성

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,9 @@
-FROM node:16-alpine as builder
-
-# 작업 폴더를 만들고 npm 설치
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-ENV PATH /usr/src/app/node_modules/.bin:$PATH
-COPY package.json /usr/src/app/package.json
-RUN npm install --silent
-RUN npm install react-scripts@2.1.3 -g --silent
-
-# 소스를 작업폴더로 복사하고 빌드
-COPY . /usr/src/app
-RUN npm run build
-
-
-
-FROM nginx:1.13.9-alpine
+FROM nginx
 # nginx의 기본 설정을 삭제하고 앱에서 설정한 파일을 복사
 RUN rm -rf /etc/nginx/conf.d
 COPY conf /etc/nginx
-
 # 위에서 생성한 앱의 빌드산출물을 nginx의 샘플 앱이 사용하던 폴더로 이동
-COPY --from=builder /usr/src/app/build /usr/share/nginx/html
-
+COPY build /usr/share/nginx/html
 # 80포트 오픈하고 nginx 실행
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "npm run build"
+npm run build
+
+echo "docker build"
+docker build -t kgh2120/web .
+
+echo "docker push"
+docker push kgh2120/web


### PR DESCRIPTION
### 작업 내용

**도커 파일 수정**
기존 도커 파일은 node js와 모듈들을 전부 설치한 후 빌드 하기 때문에 시간이 너무 많이 걸렸다.
그래서 이미 모듈이 설치된 로컬에서 빌드를 돌린 후 Nginx만을 도커로 구성하면 시간을 단축 시킬 수 있다고 생각하여 이를 수정

```Dockerfile
FROM nginx
# nginx의 기본 설정을 삭제하고 앱에서 설정한 파일을 복사
RUN rm -rf /etc/nginx/conf.d
COPY conf /etc/nginx

COPY build /usr/share/nginx/html  // <- 로컬의 빌드 폴더를 nginx로 전송
# 80포트 오픈하고 nginx 실행
EXPOSE 80
CMD ["nginx", "-g", "daemon off;"]
```

**빌드 스크립트 제작**
빌드하기 -> 도커 만들기 -> 도커 배포하기 과정은 너무 귀찮기 때문에, 자동으로 진행하는 빌드 스크립트 제작함.
Shell 스크립트는 윈도우 파워셸에서는 안돌아가서 git bash에서 돌려야 작동 가능.
sh build.sh 을 입력하면 작동함.

```shell
#!/bin/sh
echo "npm run build"
npm run build

echo "docker build"
docker build -t kgh2120/web . <- 사용한다면 본인 아이디/이미지이름 으로 변경 

echo "docker push"
docker push kgh2120/web <- 위와 동일한 이름/이미지이름 작성
```


