### PR TITLE
[ISSUE#119] 주문 페이지에서 옵션 및 이미지 미선택 시 alert + 스크롤 이동

### DIFF
--- a/src/component/Radio.js
+++ b/src/component/Radio.js
@@ -1,31 +1,30 @@
-import './Radio.css';
+import "./Radio.css";
 
 export default function Radio(props) {
   const radioButtons = document.querySelectorAll(
-    'input[type="radio"][name=' + props.name + ']'
+    'input[type="radio"][name=' + props.name + "]"
   );
 
   return (
     <div className="radio" style={props.style}>
       <input
-        id={'radio ' + props.text}
+        id={"radio " + props.text}
         type="radio"
         name={props.name}
         value={props.text}
-        required={props.required}
         checked={props.checked}
-        onChange={e => {
+        onChange={(e) => {
           props.onChange(e);
-          radioButtons.forEach(rb => {
+          radioButtons.forEach((rb) => {
             if (rb === e.target) {
-              if (!rb.checked) rb.toggleAttribute('checked');
+              if (!rb.checked) rb.toggleAttribute("checked");
             } else {
-              if (rb.checked) rb.toggleAttribute('checked');
+              if (rb.checked) rb.toggleAttribute("checked");
             }
           });
         }}
       />
-      <label htmlFor={'radio ' + props.text}>{props.text}</label>
+      <label htmlFor={"radio " + props.text}>{props.text}</label>
     </div>
   );
 }

--- a/src/screen/product/order/Order.css
+++ b/src/screen/product/order/Order.css
@@ -30,7 +30,7 @@
 .add-material,
 .add-image,
 .quantity {
-  margin-bottom: 110px;
+  padding: 60px 0;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/screen/product/order/Order.js
+++ b/src/screen/product/order/Order.js
@@ -53,15 +53,29 @@ const Order = () => {
         post(dto, imageFile);
         break;
       case "buy":
-        navigate("/payment", {
-          state: {
-            mounting_method: `${formValue.mounting_method}`,
-            basic_material: `${formValue.basic_material}`,
-            add_material: `${formValue.add_material}`,
-            add_image: imageFile,
-            quantity: `${formValue.quantity}`,
-          },
-        });
+        if (!formValue.mounting_method) {
+          alert("거치 방식을 입력해주세요");
+          window.location.href = "#mounting-method";
+        } else if (!formValue.basic_material) {
+          alert("기본소재를 입력해주세요");
+          window.location.href = "#basic-material";
+        } else if (!formValue.add_material) {
+          alert("기본 소재 옵션을 입력해주세요");
+          window.location.href = "#add-material";
+        } else if (!imageFile) {
+          alert("이미지를 입력해주세요");
+          window.location.href = "#add-image";
+        } else {
+          navigate("/payment", {
+            state: {
+              mounting_method: `${formValue.mounting_method}`,
+              basic_material: `${formValue.basic_material}`,
+              add_material: `${formValue.add_material}`,
+              add_image: imageFile,
+              quantity: `${formValue.quantity}`,
+            },
+          });
+        }
         break;
     }
   };
@@ -105,7 +119,7 @@ const Order = () => {
           <div className="order-options">
             <form className="order-inputs" onSubmit={onHandleSubmit}>
               <div className="order-inputs-selects">
-                <div className="mounting-method">
+                <div id="mounting-method" className="mounting-method">
                   <div className="order-title">거치 방식을 선택하세요</div>
                   <Radio
                     style={{ marginBottom: "10px" }}
@@ -121,7 +135,7 @@ const Order = () => {
                     required
                   />
                 </div>
-                <div className="basic-material">
+                <div id="basic-material" className="basic-material">
                   <div className="order-title">기본소재를 선택하세요</div>
                   <Radio
                     name="basic_material"
@@ -130,7 +144,7 @@ const Order = () => {
                     required
                   />
                 </div>
-                <div className="add-material">
+                <div id="add-material" className="add-material">
                   <div className="order-title">
                     추가 하고 싶은 기본소재 옵션을 <br />
                     선택하세요
@@ -165,7 +179,7 @@ const Order = () => {
                     />
                   </div>
                 </div>
-                <div className="add-image">
+                <div id="add-image" className="add-image">
                   <div className="order-title">나만의 개성을 추가해봐요</div>
                   <div className="radio-btn">
                     <ImageInput width="60px" height="60px" />


### PR DESCRIPTION
### ISSUE https://github.com/Liberty52/front-end/issues/119
: 주문 페이지에서 옵션 및 이미지를 선택하지 않았을 때 alert를 보여준 후 미입력한 옵션 또는 이미지 입력창으로 이동합니다.

______________________________________________________________
**ex) 기본 소재입력하지 않았을 때,**

1. alert 출력

> <img width="500" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/6b6ddb3a-1f56-41a5-9ee7-18bc5681e13d">

2. 기본 소재 입력창으로 이동 (= 링크 #basic-material로 이동)

> <img width="500" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/ae6411ac-6f7d-4256-82eb-0db81ec4a098">