### PR TITLE
비회원 주문 취소 활성화

### DIFF
--- a/src/axios/inquiry/Inquiry.js
+++ b/src/axios/inquiry/Inquiry.js
@@ -7,11 +7,11 @@ export function fetchOrders(sessionToken) {
   });
 }
 
-export function cancelOrder(dto) {
+export function cancelOrder(dto, receiverPhoneNumber) {
   axios
     .post("/product/orders/cancel", JSON.stringify(dto), {
       headers: {
-        Authorization: sessionStorage.getItem(ACCESS_TOKEN),
+        Authorization: sessionStorage.getItem(ACCESS_TOKEN) ?  sessionStorage.getItem(ACCESS_TOKEN) : receiverPhoneNumber,
         "Content-Type": `application/json`,
       },
     })

--- a/src/component/inquiry/CancelModal.js
+++ b/src/component/inquiry/CancelModal.js
@@ -27,7 +27,7 @@ export default function CancelModal({ order, closeModal }) {
             dto["refundAccount"] = e.target.refundAccount.value;
             dto["refundPhoneNum"] = e.target.refundPhoneNum.value;
           }
-          cancelOrder(dto);
+          cancelOrder(dto, order.receiverPhoneNumber);
           closeModal();
         }}
       >


### PR DESCRIPTION
### 이슈 번호 #157

비회원이 주문 취소를 할 때 Authorization을 넘겨야 해서 수정함.

``` javascript
 Authorization: sessionStorage.getItem(ACCESS_TOKEN) ?  sessionStorage.getItem(ACCESS_TOKEN) : receiverPhoneNumber,
```
세션 스토리지에 엑세스 토큰이 없으면 전화번호를 넘기도록 수정함.