### PR TITLE
[ISSUE-160] 환불 계좌 입력창

### DIFF
--- a/src/component/common/Header.css
+++ b/src/component/common/Header.css
@@ -59,7 +59,7 @@
   display: none;
 }
 
-@media (max-width: 925px) {
+@media (max-width: 1200px) {
   .header-lg {
     display: none;
   }

--- a/src/component/inquiry/CancelModal.js
+++ b/src/component/inquiry/CancelModal.js
@@ -3,13 +3,15 @@ import Modal from "../common/Modal";
 import Button from "../common/Button";
 import Input from "../common/Input";
 import { cancelOrder } from "../../axios/inquiry/Inquiry";
+import { PAYMENT_TYPE, ORDER_STATUS } from "../../constants/order-info";
 
 import { useState } from "react";
 
 export default function CancelModal({ order, closeModal }) {
   const [text, setText] = useState("");
   const showAccountInputGroup =
-    order.paymentType === "가상 계좌" && order.orderStatus === "ORDERED";
+    order.paymentType === PAYMENT_TYPE.VBANK &&
+    order.orderStatus === ORDER_STATUS.ORDERED;
 
   return (
     <Modal title="주문 취소" closeModal={closeModal}>

--- a/src/constants/order-info.js
+++ b/src/constants/order-info.js
@@ -1,0 +1,15 @@
+export const PAYMENT_TYPE = {
+  CARD: "신용카드",
+  VBANK: "가상 계좌",
+  NAVER_PAY: "네이버 페이",
+};
+
+export const ORDER_STATUS = {
+  REFUND: "환불완료",
+  READY: "주문접수",
+  WAITING_DEPOSIT: "입금대기",
+  ORDERED: "주문완료",
+  MAKING: "제작중",
+  DELIVERING: "배송시작",
+  COMPLETE: "배송완료",
+};

--- a/src/screen/order/payment/PaymentInfo.js
+++ b/src/screen/order/payment/PaymentInfo.js
@@ -1,15 +1,16 @@
-import './PaymentInfo.css';
-import * as React from 'react';
-import { Box, Radio, RadioGroup, Sheet, Input } from '@mui/joy';
-import Select, { selectClasses } from '@mui/joy/Select';
-import Option from '@mui/joy/Option';
-import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
-import Checkbox from '../../../component/common/Checkbox';
-import { useEffect, useState } from 'react';
-import { getVBankInfos } from '../../../axios/order/Payment';
+import "./PaymentInfo.css";
+import * as React from "react";
+import { Box, Radio, RadioGroup, Sheet, Input } from "@mui/joy";
+import Select, { selectClasses } from "@mui/joy/Select";
+import Option from "@mui/joy/Option";
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+import Checkbox from "../../../component/common/Checkbox";
+import { useEffect, useState } from "react";
+import { getVBankInfos } from "../../../axios/order/Payment";
+import { PAYMENT_TYPE, ORDER_STATUS } from "../../../constants/order-info";
 
 function PaymentMethod(props) {
-  const onPMChanged = e => {
+  const onPMChanged = (e) => {
     props.setPaymentMethod(e.target.value);
   };
 
@@ -18,24 +19,24 @@ function PaymentMethod(props) {
       defaultValue="card"
       size="sm"
       sx={{
-        justifyContent: 'space-around'
-    }}
+        justifyContent: "space-around",
+      }}
       orientation="horizontal"
     >
       {[
-        { value: 'card', label: '신용카드' },
-        { value: 'vbank', label: '가상계좌' },
-      ].map(element => (
+        { value: "card", label: PAYMENT_TYPE.CARD },
+        { value: "vbank", label: PAYMENT_TYPE.VBANK },
+      ].map((element) => (
         <Sheet
           key={element.value}
           sx={{
             width: 130,
-            textAlign: 'center',
+            textAlign: "center",
             fontSize: 11,
             p: 0.5,
-            borderRadius: 'sm',
-            boxShadow: 'sm',
-            bgcolor: 'background.body',
+            borderRadius: "sm",
+            boxShadow: "sm",
+            bgcolor: "background.body",
           }}
         >
           <Radio
@@ -47,16 +48,16 @@ function PaymentMethod(props) {
             slotProps={{
               label: ({ checked }) => ({
                 sx: {
-                  fontWeight: 'md',
-                  fontSize: 'md',
-                  color: checked ? 'text.primary' : 'text.secondary',
+                  fontWeight: "md",
+                  fontSize: "md",
+                  color: checked ? "text.primary" : "text.secondary",
                 },
               }),
               action: ({ checked }) => ({
-                sx: theme => ({
+                sx: (theme) => ({
                   ...(checked && {
-                    '--variant-borderWidth': '2px',
-                    '&&': {
+                    "--variant-borderWidth": "2px",
+                    "&&": {
                       // && to increase the specificity to win the base :hover styles
                       borderColor: theme.vars.palette.primary[500],
                     },
@@ -73,7 +74,7 @@ function PaymentMethod(props) {
 
 function VBankContent(props) {
   const [vbankInfos, setVbankInfos] = useState({
-    vbanks: [{ vbank: '' }],
+    vbanks: [{ vbank: "" }],
   });
 
   useEffect(() => {
@@ -82,8 +83,7 @@ function VBankContent(props) {
         const vbankList = await getVBankInfos();
         setVbankInfos(vbankList.data);
       } catch (e) {
-        
-        alert('가상계좌 정보를 가져오는데 실패했습니다. 다시 시도해주세요.');
+        alert("가상계좌 정보를 가져오는데 실패했습니다. 다시 시도해주세요.");
       }
     };
 
@@ -91,7 +91,7 @@ function VBankContent(props) {
   }, []);
 
   const [isCashReceiptChecked, setIsCashReceiptChecked] = useState(false);
-  const handleCheckBoxChange = event => {
+  const handleCheckBoxChange = (event) => {
     setIsCashReceiptChecked(event.target.checked);
     props.setIsCashReceipt(event.target.checked);
   };
@@ -100,7 +100,7 @@ function VBankContent(props) {
     props.setVBankAccount(value);
   };
 
-  const onDepositorChange = e => {
+  const onDepositorChange = (e) => {
     props.setDepositorName(e.target.value);
   };
 
@@ -110,24 +110,24 @@ function VBankContent(props) {
         indicator={<KeyboardArrowDown />}
         sx={{
           [`& .${selectClasses.indicator}`]: {
-            transition: '0.2s',
+            transition: "0.2s",
             [`&.${selectClasses.expanded}`]: {
-              transform: 'rotate(-180deg)',
+              transform: "rotate(-180deg)",
             },
           },
-          fontFamily: 'inherit',
+          fontFamily: "inherit",
           fontSize: 13,
-          minHeight: '34px',
+          minHeight: "34px",
         }}
         onChange={onAccountChange}
-        placeholder={'가상계좌를 선택해주세요.'}
+        placeholder={"가상계좌를 선택해주세요."}
       >
-        {vbankInfos.vbanks.map(data => (
+        {vbankInfos.vbanks.map((data) => (
           <Option
             key={data.vbank}
             value={data.vbank}
             sx={{
-              fontFamily: 'inherit',
+              fontFamily: "inherit",
               fontSize: 13,
             }}
           >
@@ -138,16 +138,16 @@ function VBankContent(props) {
 
       <Box
         sx={{
-          alignItems: 'center',
-          flexWrap: 'wrap',
+          alignItems: "center",
+          flexWrap: "wrap",
         }}
       >
         <Input
           sx={{
-            fontFamily: 'inherit',
+            fontFamily: "inherit",
             fontSize: 13,
-            minHeight: '34px',
-            '--Input-focusedThickness': '1px',
+            minHeight: "34px",
+            "--Input-focusedThickness": "1px",
           }}
           onChange={onDepositorChange}
           placeholder="입금자명 (미입력시 주문자명)"
@@ -170,8 +170,8 @@ export default function PaymentInfo(props) {
 
   const [pm, setPm] = useState({ pm: PM_CARD });
 
-  const setPaymentMethod = newPaymentMethod => {
-    props.setPayment(prevState => {
+  const setPaymentMethod = (newPaymentMethod) => {
+    props.setPayment((prevState) => {
       return { ...prevState, paymentMethod: newPaymentMethod };
     });
     setPm(newPaymentMethod);
@@ -182,20 +182,20 @@ export default function PaymentInfo(props) {
     }
   };
 
-  const setVBankAccount = newAccount => {
-    props.setPayment(prevState => {
+  const setVBankAccount = (newAccount) => {
+    props.setPayment((prevState) => {
       return { ...prevState, vBankAccount: newAccount };
     });
   };
 
-  const setDepositorName = newDepositor => {
-    props.setPayment(prevState => {
+  const setDepositorName = (newDepositor) => {
+    props.setPayment((prevState) => {
       return { ...prevState, depositorName: newDepositor };
     });
   };
 
-  const setIsCashReceipt = newValue => {
-    props.setPayment(prevState => {
+  const setIsCashReceipt = (newValue) => {
+    props.setPayment((prevState) => {
       return { ...prevState, isCashReceipt: newValue };
     });
   };


### PR DESCRIPTION
### ISSUE #160 
**원인**
: 기존 코드는 입력창 여부를 다음의 코드로 확인
`order.paymentType === "가상 계좌" && order.orderStatus === `"ORDERED";``
-> 백엔드에서 orderStatus를 영어에서 한글로 리턴시켜주면서 문제 발생

__________________________________________

- **결제유형, 주문상태 constant로 변경**

```
export const PAYMENT_TYPE = {
  CARD: "신용카드",
  VBANK: "가상 계좌",
  NAVER_PAY: "네이버 페이",
};

export const ORDER_STATUS = {
  REFUND: "환불완료",
  READY: "주문접수",
  WAITING_DEPOSIT: "입금대기",
  ORDERED: "주문완료",
  MAKING: "제작중",
  DELIVERING: "배송시작",
  COMPLETE: "배송완료",
};
```

- **constant로 체크**

```
    order.paymentType === PAYMENT_TYPE.VBANK &&
    order.orderStatus === ORDER_STATUS.ORDERED;
```