### PR TITLE
[ISSUE-166] 헤더 이슈 해결

### DIFF
--- a/src/component/common/Header.css
+++ b/src/component/common/Header.css
@@ -73,10 +73,12 @@
     display: flex;
     opacity: 0;
     height: 30px;
+    visibility: hidden;
   }
 
   .header-items-group .bar-active {
     opacity: 100%;
+    visibility: visible;
   }
 
   .header-fixed .header-items-group .bar {


### PR DESCRIPTION
### ISSUE #166 

- **원인**
: opacity를 이용해서 투명도만 설정해줬기 때문에
보이지 않는(opacity: 0) 요소도 clickable

- **해결**
: visibility: hidden, visibility: visible 추가
```
  .header-items-group .bar {
    display: flex;
    opacity: 0;
    height: 30px;
    visibility: hidden; <<
  }

  .header-items-group .bar-active {
    opacity: 100%;
    visibility: visible; <<
  }
```