### PR TITLE
Bug: resloved that updated password page rendering error

### DIFF
--- a/src/screen/login/changePassword/ChangePassword.js
+++ b/src/screen/login/changePassword/ChangePassword.js
@@ -7,8 +7,6 @@ import Input from "../../../component/common/Input";
 import Button from "../../../component/common/Button";
 
 export default function ChangePassword() {
-    const [newPassword, setNewPassword] = useState("");
-    const [confirmNewPassword, setConfirmNewPassword] = useState("");
     const [errorMessage, setErrorMessage] = useState("");
     const [isSuccess, setIsSuccess] = useState(false);
     const navigate = useNavigate();
@@ -29,6 +27,9 @@ export default function ChangePassword() {
     const handleSubmit = async (e) => {
       e.preventDefault();
 
+      const newPassword = e.target.newPassword.value;
+      const confirmNewPassword = e.target.confirmNewPassword.value;
+
       if (newPassword !== confirmNewPassword) {
         setErrorMessage("새로운 비밀번호와 새로운 비밀번호 확인이 일치하지 않습니다.");
         return;
@@ -48,7 +49,7 @@ export default function ChangePassword() {
     };
 
      if (isSuccess) {
-       navigate("/Login"); //로그인
+       navigate("/login"); //로그인
      }
 
     return (
@@ -57,23 +58,11 @@ export default function ChangePassword() {
       <form onSubmit={handleSubmit}>
         <div>
           <label htmlFor="new-password">새로운 비밀번호:</label>
-          <Input
-            type="password"
-            name="new-password"
-            value={newPassword}
-            required={true}
-            onChange={(e) => setNewPassword(e.target.value)}
-          />
+          <Input type="password" name="newPassword" required={true} />
         </div>
         <div>
           <label htmlFor="confirm-new-password">새로운 비밀번호 확인:</label>
-          <Input
-            type="password"
-            name="confirm-new-password"
-            value={confirmNewPassword}
-            required={true}
-            onChange={(e) => setConfirmNewPassword(e.target.value)}
-          />
+          <Input type="password" name="confirmNewPassword" required={true} />
         </div>
         <Button text="비밀번호 변경"/>
       </form>


### PR DESCRIPTION
#190 

패스워드 변경 페이지 렌더링 오류.

원인:
- `Input` 컴포넌트의 attr. 중 `name`의 값이 없어서 발생

해결:
- 패스워드 변경 페이지에서 `Input` 컴포넌트를 생성할 때의 props로 `id`를 `name`으로 변경함.