### PR TITLE
[FEAT] 상품 소개, 리뷰 탭으로 변경

### DIFF
--- a/src/component/order/Introduction.js
+++ b/src/component/order/Introduction.js
@@ -1,0 +1,8 @@
+// 상품 소개
+export default function Introduction({ introductionImageUrl }) {
+  return introductionImageUrl ? (
+    <img src={introductionImageUrl} alt="상품 정보" style={{ width: "100%" }} />
+  ) : (
+    <div style={{ textAlign: "center" }}>상품 정보가 없습니다</div>
+  );
+}

--- a/src/component/order/OrderTab.js
+++ b/src/component/order/OrderTab.js
@@ -3,6 +3,14 @@ import PropTypes from "prop-types";
 import { useState } from "react";
 import Review from "./review/Review";
 import Introduction from "./Introduction";
+import styled from "styled-components";
+
+const OrderTabBox = styled(Box)`
+  margin: 0 200px;
+  @media screen and (max-width: 768px) {
+    margin: 0;
+  }
+`;
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -54,7 +62,7 @@ export default function OrderTab({ introductionImageUrl }) {
   ];
 
   return (
-    <Box sx={{ margin: "0 200px" }}>
+    <OrderTabBox>
       <Box
         sx={{
           borderBottom: 1,
@@ -90,6 +98,6 @@ export default function OrderTab({ introductionImageUrl }) {
           </TabPanel>
         );
       })}
-    </Box>
+    </OrderTabBox>
   );
 }

--- a/src/component/order/OrderTab.js
+++ b/src/component/order/OrderTab.js
@@ -1,0 +1,95 @@
+import { Box, Tabs, Tab } from "@mui/material";
+import PropTypes from "prop-types";
+import { useState } from "react";
+import Review from "./review/Review";
+import Introduction from "./Introduction";
+
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`product-tabpanel-${index}`}
+      aria-labelledby={`product-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+function a11yProps(index) {
+  return {
+    id: `product-tab-${index}`,
+    "aria-controls": `product-tabpanel-${index}`,
+  };
+}
+
+export default function OrderTab({ introductionImageUrl }) {
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  const tabConfigs = [
+    {
+      value: "intro",
+      label: "상품 소개",
+      content: <Introduction introductionImageUrl={introductionImageUrl} />,
+    },
+    {
+      value: "review",
+      label: "리뷰",
+      content: <Review />,
+    },
+  ];
+
+  return (
+    <Box sx={{ margin: "0 200px" }}>
+      <Box
+        sx={{
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        <Tabs
+          sx={{ mt: 7 }}
+          value={value}
+          onChange={handleChange}
+          aria-label="basic tabs example"
+          centered
+        >
+          {tabConfigs.map((t, i, arr) => {
+            return (
+              <Tab
+                key={i}
+                sx={{
+                  fontSize: 18,
+                  fontWeight: "bold",
+                }}
+                label={t.label}
+                {...a11yProps(i)}
+              />
+            );
+          })}
+        </Tabs>
+      </Box>
+      {tabConfigs.map((t, i, arr) => {
+        return (
+          <TabPanel key={i} value={value} index={i}>
+            {t.content}
+          </TabPanel>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/component/order/review/Review.css
+++ b/src/component/order/review/Review.css
@@ -1,39 +1,15 @@
 .review {
-  padding: 40px 200px 15px;
+  padding-bottom: 15px;
 }
 
-.review .tab {
-  padding: 7px 0;
-  border-bottom: 1px solid gray;
-  text-align: center;
-}
-
-.review .title-div {
-  margin: 13px 0;
+.review .review-content {
+  margin: 15px 0;
 }
 
 .review .filter,
-.review .review-content .review-header,
-.review .review-content,
 .review .content,
 .review .pages {
   margin: 8px 0;
-}
-
-.review .title-div {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.review .title-div .title {
-  font-size: 15px;
-  font-weight: bold;
-}
-
-.review .title-div .button {
-  width: auto;
-  padding: 6px 10px;
 }
 
 .review .filter {
@@ -102,7 +78,7 @@
   color: black;
   font-weight: bold;
 }
-.pages span:hover{
+.pages span:hover {
   cursor: pointer;
 }
 @media screen and (max-width: 500px) {

--- a/src/component/order/review/Review.js
+++ b/src/component/order/review/Review.js
@@ -191,11 +191,6 @@ export default function Review() {
 
   return (
     <div className="review">
-      <div className="tab">리뷰</div>
-      <div className="title-div">
-        <div className="title">구매평 (개수)</div>
-      </div>
-      <div className="button-div"></div>
       <div className="filter">
         <Checkbox
           text="포토 구매평만 보기"

--- a/src/screen/order/Order.js
+++ b/src/screen/order/Order.js
@@ -1,7 +1,6 @@
 import "./Order.css";
 import Header from "../../component/common/Header";
 import Footer from "../../component/common/Footer";
-import Review from "./review/Review";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import product_img from "../../image/icon/product.png";
@@ -14,6 +13,7 @@ import $ from "jquery";
 import useAppContext from "../../hooks/useAppContext";
 import Swal from "sweetalert2";
 import { getProductInfo } from "../../axios/order/Order";
+import OrderTab from "../../component/order/OrderTab";
 
 const Order = () => {
   const { frameOption, setFrameOption } = useAppContext();
@@ -214,12 +214,7 @@ const Order = () => {
           </div>
         </div>
       </div>
-      <img
-        src={productInfo.introductionImageUrl}
-        alt="상품 정보"
-        style={{ width: "70%", margin: "auto", display: "block" }}
-      />
-      <Review />
+      <OrderTab introductionImageUrl={productInfo.introductionImageUrl} />
       <Footer />
     </div>
   );


### PR DESCRIPTION
# [주문 페이지] 상세 정보랑 리뷰 탭으로 바꿔주세요 https://github.com/Liberty52/front-end/issues/135
## [UI] 탭 추가
OrderTab
- Review.js
- Introduction.js

### 참고 이미지
- 소개 탭 활성화
<img width="1280" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/2038d899-ea6e-4334-a685-8d238c82a704">

- 리뷰 탭 활성화
<img width="1280" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/3b8a1f02-dc36-49c6-9cb4-4f367bb78e62">

## Review js 및 css 파일 이동
src/screen/order/review/Review.js → src/component/order/review/Review.js
## 상품 소개 이미지 없는 경우
### 참고 이미지
<img width="1280" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/e48ec4bd-d08d-4119-8838-43f0dd62b3bc">

## 주문 탭 반응형
<img width="283" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/8a6e013f-b7b6-4cbf-8104-0153d8cc8e94">
<img width="282" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/40e400f0-a978-40ed-b00f-9a723d24cc25">