### PR TITLE
[BUGFIX] Input Label 연결

### DIFF
--- a/src/component/common/Input.js
+++ b/src/component/common/Input.js
@@ -1,22 +1,23 @@
-import './Input.css';
-import { useState, useEffect } from 'react';
+import "./Input.css";
+import { useState, useEffect } from "react";
 
 export default function Input(props) {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState("");
 
   useEffect(() => {
-    setValue(props.value ? props.value : '');
+    setValue(props.value ? props.value : "");
   }, [props.value]);
 
   useEffect(() => {
     if (!value)
-      document.querySelector('#' + props.name).classList.remove('value');
-    else document.querySelector('#' + props.name).classList.add('value');
+      document.querySelector("#" + props.name).classList.remove("value");
+    else document.querySelector("#" + props.name).classList.add("value");
   }, [value]);
 
   return (
     <div id={props.name} className="input-block">
       <input
+        id={props.name + "-input"}
         className="input"
         type={props.type}
         name={props.name}
@@ -27,15 +28,15 @@ export default function Input(props) {
         value={value}
         readOnly={props.readOnly}
         checked={props.checked}
-        onChange={e => {
+        onChange={(e) => {
           setValue(e.target.value);
         }}
         onClick={props.onClick}
         autoComplete="off"
       />
-      <label htmlFor={props.name} className="label">
+      <label htmlFor={props.name + "-input"} className="label">
         {props.label}
-        {props.required ? ' (필수)' : ''}
+        {props.required ? " (필수)" : ""}
       </label>
     </div>
   );


### PR DESCRIPTION
# Input 컴포넌트 label 눌렀을 때 입력 활성화 안되는 버그 https://github.com/Liberty52/front-end/issues/205
### 원인
**input(id)와 label(htmlFor)을 연결하지 않아서** label을 눌렀을 때 input이 focus-visible 상태가 되지 않음

### 해결
Input.js 20, 37번째 줄만 보면 됩니다. ~~나머지는 prettier로 인한 변경사항임~~
- input에는 id를 추가하고
- label에는 htmlFor을 input의 id와 같도록 함
```html
  return (
      <input
        id={props.name + "-input"} // id
      />
      <label htmlFor={props.name + "-input"} className="label"> // htmlFor
      </label>
  );
```