### PR TITLE
[FEAT] 옵션 별 재고, 추가 금액

### DIFF
--- a/src/component/common/Radio.css
+++ b/src/component/common/Radio.css
@@ -1,11 +1,11 @@
-.radio input[type='radio'] {
+.radio input[type="radio"] {
   display: none;
 }
 
 .radio label {
   width: 100%;
   display: inline-block;
-  padding: 10px 0;
+  padding: 10px 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
@@ -13,7 +13,7 @@
 }
 
 /* Checked */
-.radio input[type='radio']:checked + label {
+.radio input[type="radio"]:checked + label {
   border: 1.5px solid #0071e3;
 }
 
@@ -23,6 +23,6 @@
   border-color: #aaa;
 }
 
-.radio input[type='radio']:checked + label:hover {
+.radio input[type="radio"]:checked + label:hover {
   background-color: #eef6ff;
 }

--- a/src/component/common/Radio.js
+++ b/src/component/common/Radio.js
@@ -23,7 +23,10 @@ export default function Radio(props) {
           });
         }}
       />
-      <label htmlFor={"radio " + props.text}>{props.text}</label>
+      <label htmlFor={"radio " + props.text}>
+        {props.text}
+        {props.children}
+      </label>
     </div>
   );
 }

--- a/src/screen/order/Order.js
+++ b/src/screen/order/Order.js
@@ -27,7 +27,6 @@ const Order = () => {
   const retriveProductData = () => {
     getProductInfo(productId).then((res) => {
       setProductInfo(res.data);
-      console.log(res.data);
       setPrice(res.data.price);
     });
   };

--- a/src/screen/order/Order.js
+++ b/src/screen/order/Order.js
@@ -27,6 +27,7 @@ const Order = () => {
   const retriveProductData = () => {
     getProductInfo(productId).then((res) => {
       setProductInfo(res.data);
+      console.log(res.data);
       setPrice(res.data.price);
     });
   };
@@ -163,7 +164,14 @@ const Order = () => {
                                   onHandleChange(e, item.price);
                                 }}
                                 required
-                              />
+                              >
+                                <span style={{ color: "#bbbbbb" }}>
+                                  {` + ${item.price}원`}
+                                </span>
+                                <span style={{ display: "none" }}>
+                                  {item.stock}
+                                </span>
+                              </Radio>
                             );
                           })}
                       </div>


### PR DESCRIPTION
# [주문 페이지] 재고 확인 https://github.com/Liberty52/front-end/issues/207
## [[FEAT] 옵션 별 재고, 추가 금액](https://github.com/Liberty52/front-end/commit/69d3a5971b9c55a9fbe433f531822fbaadcf8261)
### 주문 페이지 라디오 버튼 CSS
horizontal padding 0 -> 10px
```css
.radio label {
  padding: 10px 10px;
}
```
### 옵션 별 추가 금액, 재고 추가
#### 이미지
<img width="1280" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/ab1c6272-b89d-46de-bfee-505fe5577734">

#### 코드
```javascript
<Radio>
  <span style={{ color: "#bbbbbb" }}>
    {` + ${item.price}원`}
  </span>
  <span style={{ display: "none" }}>
    {item.stock}
  </span>
</Radio>
```
