### PR TITLE
주문 요청 시 옵션명이 아닌 옵션 ID로 요청하도록 API 수정

### DIFF
--- a/src/screen/order/Order.js
+++ b/src/screen/order/Order.js
@@ -47,10 +47,10 @@ const Order = () => {
   let imageFile = "";
   const navigate = useNavigate();
 
-  const onHandleChange = (e, itemPrice) => {
+  const onHandleChange = (e, item, itemPrice) => {
     setFrameOption({
       ...frameOption,
-      [e.target.name]: e.target.value,
+      [e.target.name]: item,
     });
     setAdditionalPrice({
       ...additionalPrice,
@@ -61,7 +61,7 @@ const Order = () => {
   const onHandleSubmit = (e) => {
     e.preventDefault();
     const options = Object.values(frameOption).map((item) => {
-      return item;
+      return item.name;
     });
     const image = e.target.file.files[0];
     const data = {
@@ -187,7 +187,7 @@ const Order = () => {
                                 name={option.name}
                                 text={item.name}
                                 onChange={(e) => {
-                                  onHandleChange(e, item.price);
+                                  onHandleChange(e, item, item.price);
                                 }}
                                 required
                               >

--- a/src/screen/order/payment/Payment.js
+++ b/src/screen/order/payment/Payment.js
@@ -149,7 +149,7 @@ function Product(props) {
         <div className="title">Liberty 52_Frame</div>
         <div>
           {Object.values(productInfo.frameOption).map((option, idx) => {
-            return <div key={idx}>{option}</div>;
+            return <div key={idx}>{option.name}</div>;
           })}
         </div>
       </div>
@@ -301,9 +301,9 @@ function ConfirmSection(props) {
   }
   const length = productInfoList.length;
   const productDto = {
-    productName: "Liberty 52_Frame",
-    options: Object.values(productInfoList[0].frameOption).map((option) => {
-      return option;
+    productName: "Liberty 52_Frame", 
+    optionDetailIds: Object.values(productInfoList[0].frameOption).map((optionDetail) => {
+      return optionDetail.id
     }),
     quantity: props.productInfo.quantity,
   };
@@ -487,7 +487,6 @@ function ConfirmSection(props) {
         </div>
         {productInfoList.map((productInfo) => {
           totalPrice += productInfo.price;
-          console.log(totalPrice);
           return (
             <>
               <Product productInfo={productInfo} />


### PR DESCRIPTION
# 주문 요청 시 옵션명이 아닌 옵션 ID로 요청하도록 API 수정

Resolve #228 

- `Order.js`에서 옵션을 선택하는 radio 버튼의 클릭 이벤트 발생 시 `e.target.value` 가 아닌 `item` 객체를 `frameOptions`에 저장.
- 장바구니는 @Autumn-Rainfall 님 담당이기에 기존 방식인 option의 이름을 dto로 만들도록 수정
- 단건 주문 시 `Payment.js`에서 `frameOptions`로 받아온 객체 중 `optionDetail`에 해당하는 부분의 DTO를 생성할 때, `return optionDetail.id`를 통해 옵션 디테일 아이디 배열로 수정

콘솔 로그로만 `productDto`를 확인해 본 결과, 수정된 API와 동일한 것으로 확인.
별도로 API 테스트는 해보지 못하였습니다.