### PR TITLE
[ISSUE-280] npm 종속성으로 인한 build fail 문제 예방

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "export { SOCIAL_LOGIN_URL };" >> src/global/url.js
 
       - name: 의존성 설치
-        run: npm install
+        run: npm install --force
 
       - name: 빌드
         run: CI=false npm run build

--- a/multistage.Dockerfile
+++ b/multistage.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16 AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --production --force
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
### 예상되는 문제 상황
일부 모듈의 peer 의존성으로 인한 빌드 실패

### 해결 방안
`npm install` 시  `--force` 나 `--legacy-peer-deps` 옵션 추가

### 코드

```yml
# ci.yml
name: CI - 빌드
on:
  pull_request:
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: 코드 체크아웃
        uses: actions/checkout@v2
      - name: Node.js 버전 설정
        uses: actions/setup-node@v2
        with:
          node-version: 16
      - name: 의존성 설치
        run: npm install --force
      - name: 빌드
        run: CI=false npm run build
```

```dockerfile
FROM node:16 AS build
WORKDIR /app
COPY package*.json ./
RUN npm install --production --force
COPY . .
RUN npm run build

FROM nginx:stable-alpine
RUN rm -rf /etc/nginx/conf.d
COPY conf /etc/nginx
COPY --from=build /app/build /usr/share/nginx/html
EXPOSE 80
CMD ["nginx", "-g", "daemon off;"]
```


### 테스트

**ci 스크립트**
![image](https://github.com/Liberty52/front-end/assets/46955032/2cb67e82-aa9b-4503-8afb-b291e4295146)



**multistage docker 스크립트**
![image](https://github.com/Liberty52/front-end/assets/46955032/3d4cf295-ae95-49e6-b43d-a84e0616f177)


Closes #280 

