### PR TITLE
[ISSUE-282] 공지 댓글 추가 작업

### DIFF
--- a/src/axios/support/Notice.js
+++ b/src/axios/support/Notice.js
@@ -16,8 +16,13 @@ export const retrieveNoticeDetail = (noticeId) => {
   return request.get(NOTICE_DETAIL(noticeId));
 };
 
-export const retrieveComments = (noticeId, page) => {
-  return request.get(GET_NOTICE_COMMENT(noticeId, page - 1, 10, 'createdAt', 'desc'));
+export const retrieveComments = (noticeId, page, logined) => {
+  const headers = logined
+    ? {
+        Authorization: sessionStorage.getItem(ACCESS_TOKEN),
+      }
+    : {};
+  return request.get(GET_NOTICE_COMMENT(noticeId, page - 1, 10, 'createdAt', 'desc'), { headers });
 };
 
 export const postComment = (noticeId, content) => {

--- a/src/component/support/NoticeComment.js
+++ b/src/component/support/NoticeComment.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 import {
   CommentListContainer,
   CommentContainer,
@@ -11,9 +11,9 @@ import {
   Content,
   Date,
   Page,
-} from "./style/Notice";
-import { postComment, retrieveComments } from "../../axios/support/Notice";
-import { ACCESS_TOKEN } from "../../constants/token";
+} from './style/Notice';
+import { postComment, retrieveComments } from '../../axios/support/Notice';
+import { ACCESS_TOKEN } from '../../constants/token';
 
 export default function NoticeComment({ noticeId }) {
   const [comments, setComments] = useState([]);
@@ -29,7 +29,7 @@ export default function NoticeComment({ noticeId }) {
   }, [pages.currentPage]);
 
   const getComment = async () => {
-    const res = await retrieveComments(noticeId, pages.currentPage);
+    const res = await retrieveComments(noticeId, pages.currentPage, logined);
     setComments(res.data.content);
     setPages({
       startPage: 1,
@@ -42,16 +42,16 @@ export default function NoticeComment({ noticeId }) {
     e.preventDefault();
 
     const content = e.target.content.value;
-    if (content === "") {
-      alert("댓글 내용을 입력해주세요");
+    if (content === '') {
+      alert('댓글 내용을 입력해주세요');
       return;
     }
     const res = await postComment(noticeId, content);
     if (res.status === 200) {
       getComment();
-      e.target.content.value = "";
+      e.target.content.value = '';
     } else if (res.status === 401) {
-      alert("로그인이 필요한 기능입니다");
+      alert('로그인이 필요한 기능입니다');
     }
   };
 
@@ -72,14 +72,14 @@ export default function NoticeComment({ noticeId }) {
     for (let i = 1; i <= pages.lastPage; i++) {
       pageComponents.push(
         <Page
-          style={{ fontWeight: i === pages.currentPage && "bold" }}
+          style={{ fontWeight: i === pages.currentPage && 'bold' }}
           key={i}
           onClick={() => {
             if (i !== pages.currentPage) setPages({ ...pages, currentPage: i });
           }}
         >
           {i}
-        </Page>
+        </Page>,
       );
     }
     return <PageContainer>{pageComponents}</PageContainer>;
@@ -89,9 +89,7 @@ export default function NoticeComment({ noticeId }) {
     <>
       <CommentListContainer>
         {comments.length === 0 ? (
-          <div style={{ textAlign: "center", marginBottom: "10px" }}>
-            작성된 댓글이 없습니다
-          </div>
+          <div style={{ textAlign: 'center', marginBottom: '10px' }}>작성된 댓글이 없습니다</div>
         ) : (
           comments.map((comment) => {
             return <CommentItem key={comment.commentId} comment={comment} />;
@@ -101,12 +99,12 @@ export default function NoticeComment({ noticeId }) {
       <Pages />
       <InputContainer onSubmit={submitComment}>
         <CommentInput
-          name="content"
-          variant="outlined"
-          placeholder={logined ? "" : "댓글 작성을 위해 로그인이 필요합니다"}
+          name='content'
+          variant='outlined'
+          placeholder={logined ? '' : '댓글 작성을 위해 로그인이 필요합니다'}
           disabled={!logined}
         />
-        <CommentButton type="submit" disabled={!logined}>
+        <CommentButton type='submit' disabled={!logined}>
           작성
         </CommentButton>
       </InputContainer>
@@ -115,10 +113,10 @@ export default function NoticeComment({ noticeId }) {
 }
 
 function formatDate(date) {
-  var dateParts = date.split("T");
+  var dateParts = date.split('T');
   var datePart = dateParts[0];
-  var timePart = dateParts[1].split(".")[0].slice(0, 5);
-  var formattedDate = datePart + " " + timePart;
+  var timePart = dateParts[1].split('.')[0].slice(0, 5);
+  var formattedDate = datePart + ' ' + timePart;
 
   return formattedDate;
 }

--- a/src/component/support/NoticeDetail.js
+++ b/src/component/support/NoticeDetail.js
@@ -44,7 +44,7 @@ export default function NoticeDetail({ noticeId, clearNoticeId }) {
         )}
       </NoticeDetailHeader>
       <Viewer id={'viewer'}></Viewer>
-      <NoticeComment noticeId={noticeId} />
+      {data?.commentable && <NoticeComment noticeId={noticeId} />}
       {data ? (
         <DetailPageButtonWrapper>
           <MoveToListButton onClick={clearNoticeId}>목록</MoveToListButton>


### PR DESCRIPTION
## 1. [[FEAT] 댓글 허용되지 않은 경우 컴포넌트 숨김](https://github.com/Liberty52/front-end/commit/263acfa4e4f011180790c9c8e6cc583e9bcf17a1)

### 코드
commentable 속성이 True일 때만 NoticeComment 컴포넌트를 보이도록 하였습니다
```javascript
{data?.commentable && <NoticeComment noticeId={noticeId} />}
```

### 테스트
- 댓글 허용되지 않은 공지 조회
<img width="337" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/03844b33-5b0b-40d6-910b-0edcd344804d">

___

## 2. [[API] 로그인 회원인 경우 댓글 조회 시 Authorization 추가](https://github.com/Liberty52/front-end/commit/c076817152a588a7f75fc556c6d09e3199c454fc)

### 코드
logined가 True일 때, (sessionStorage.getItem(ACCESS_TOKEN)가 존재하는 경우) 즉 로그인 상태일 때, header에 Authorization을 추가합니다.

``` javascript
export const retrieveComments = (noticeId, page, logined) => {
  const headers = logined
    ? {
        Authorization: sessionStorage.getItem(ACCESS_TOKEN),
      }
    : {};
  return request.get(GET_NOTICE_COMMENT(noticeId, page - 1, 10, 'createdAt', 'desc'), { headers });
};
```

### 테스트
- 비로그인 상태
<img width="881" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/1286efb5-a0e4-49ff-a19c-d006a5d0e809">

- 로그인 상태
<img width="860" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/3439bcee-9cc6-4edc-b645-10f020b499df">

Authorization: Bearer eyj...
