### PR TITLE
[이미지에디터] 상품 페이지로 돌아가기 오류

### DIFF
--- a/src/component/order/editor/toolbax/items/Canvas.js
+++ b/src/component/order/editor/toolbax/items/Canvas.js
@@ -33,7 +33,7 @@ const Canvas = () => {
               showArrow={true}
               accessibilityType='tooltip'
             >
-              <Button size={SIZE.compact} kind={KIND.tertiary} onClick={() => navigate('/order')}>
+              <Button size={SIZE.compact} kind={KIND.tertiary} onClick={() => navigate(-1)}>
                 상품 페이지로 돌아가기
               </Button>
             </StatefulTooltip>


### PR DESCRIPTION
### 원인
상품 페이지로 돌아가기 버튼 클릭 시 '/order' 로 간다. 하지만 order 페이지는 productId가 필요함

### 해결
navigate의 인자로 -1을 주어 전 페이지로 이동

### 참고

https://github.com/Liberty52/front-end/assets/68272931/dd55453c-e80f-43ca-a38d-258e507a05fb

