### PR TITLE
[CSS] Admin page 미리보기와 css 동일하게 변경

### DIFF
--- a/src/component/order/Introduction.css
+++ b/src/component/order/Introduction.css
@@ -1,3 +1,0 @@
-.content-container img {
-  width: 100%;
-}

--- a/src/component/order/Introduction.js
+++ b/src/component/order/Introduction.js
@@ -1,5 +1,47 @@
 import { useEffect, useRef } from 'react';
-import './Introduction.css';
+import styled from 'styled-components';
+
+const IntroductionContainer = styled.div`
+  text-align: center;
+
+  > p {
+    margin: 0;
+    line-height: 160%;
+  }
+
+  img {
+    width: 60%;
+  }
+
+  button {
+    appearance: auto;
+    text-rendering: auto;
+    color: buttontext;
+    letter-spacing: normal;
+    word-spacing: normal;
+    line-height: normal;
+    text-transform: none;
+    text-indent: 0px;
+    text-shadow: none;
+    display: inline-block;
+    text-align: center;
+    align-items: flex-start;
+    cursor: default;
+    box-sizing: border-box;
+    background-color: buttonface;
+    margin: 0em;
+    padding-block: 1px;
+    padding-inline: 6px;
+    border: 1px outset buttonborder;
+    border-image: initial;
+    border-radius: 3px;
+  }
+
+  ul {
+    list-style: initial;
+  }
+`;
+
 // 상품 소개
 export default function Introduction({ content }) {
   const contentRef = useRef();
@@ -12,5 +54,5 @@ export default function Introduction({ content }) {
     }
   }, [content]);
 
-  return <div className='content-container' ref={contentRef} style={{ textAlign: 'center' }}></div>;
+  return <IntroductionContainer ref={contentRef} />;
 }


### PR DESCRIPTION
# [CSS] Admin page 미리보기와 css 동일하게 변경
### 주문 페이지
<img width="706" alt="image" src="https://github.com/Liberty52/front-end/assets/78421872/38b8dad2-e49e-42fb-905a-ba8a4d9496bb">

### 관리자 페이지
![image](https://github.com/Liberty52/front-end/assets/78421872/f3470acf-d58e-4f4e-b60f-0dc0a125d2ae)
