### PR TITLE
[bug] product name

### DIFF
--- a/src/screen/order/payment/Payment.js
+++ b/src/screen/order/payment/Payment.js
@@ -139,7 +139,7 @@ function Product(props) {
     <div className='confirm-product'>
       <img src={liberty52} alt='제품 이미지' />
       <div>
-        <div className='title'>Liberty 52_Frame</div>
+        <div className='title'>{productInfo.productName}</div>
         <div>
           {Object.values(productInfo.frameOption).map((option, idx) => {
             return <div key={idx}>{option.name}</div>;


### PR DESCRIPTION
## 원인
- Payment.js에서 product name을 liberty52로 고정했음

## 해결
- prop으로 전달된 productInfo.productName으로 변경

## 참고
![image](https://github.com/Liberty52/front-end/assets/68272931/3ca08b3c-f6f5-4e0d-b4eb-294bf26769c6)
